### PR TITLE
fix: Display Tracked vessels trajectories #16

### DIFF
--- a/components/core/map/position-preview.tsx
+++ b/components/core/map/position-preview.tsx
@@ -22,7 +22,7 @@ const PositionPreview: React.FC<PositionPreviewTypes> = () => {
           animate={{ y: 0, opacity: 1 }}
           exit={{ y: 300, opacity: 0 }}
           transition={{ type: "spring", stiffness: 66 }}
-          className="fixed bottom-0 left-1/2 ml-[-225px] w-auto -translate-x-1/2"
+          className="fixed bottom-0 right-0 mr-10 mb-2 w-auto -translate-x-1/2"
         >
           <PreviewCard vesselInfo={activePosition} />
         </motion.div>

--- a/components/core/map/preview-card.tsx
+++ b/components/core/map/preview-card.tsx
@@ -40,22 +40,14 @@ const PreviewCard: React.FC<PreviewCardTypes> = ({ vesselInfo }) => {
       : addTrackedVesselMMSI(vessel_mmsi)
   }
   return (
-    <div className="flex min-w-[650px] flex-col items-center rounded-t-lg bg-white shadow hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700 md:max-w-xl md:flex-row">
+    <div className="flex w-wrap flex-col rounded-t-lg bg-white shadow hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700 md:max-w-xl md:flex-row">
       <img
-        className="h-[350px] w-[225px] overflow-hidden rounded-tl-lg object-cover"
+        className="h-[270px] w-2/5 overflow-hidden rounded-tl-lg object-cover"
         src="/img/scrombus.jpg"
         alt="default fishing vessel image"
       />
 
-      <div className="flex grow flex-col justify-between p-4 leading-normal">
-        <div className="flex flex-row justify-end">
-          <IconButton
-            description="Close preview"
-            onClick={() => setActivePosition(null)}
-          >
-            <XIcon className="size-5 text-black dark:text-white" />
-          </IconButton>
-        </div>
+      <div className="flex grow flex-col px-4 py-2 leading-normal pt-4">
         <div className="flex w-full flex-row items-center justify-start gap-3">
           <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
             {name}
@@ -67,20 +59,20 @@ const PreviewCard: React.FC<PreviewCardTypes> = ({ vesselInfo }) => {
             height={18}
           />
         </div>
-        <section id="vessel-details" className="mb-4">
-          <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
+        <section id="vessel-details" className="mb-6">
+          <p className="mb-3 text-sm text-gray-700 dark:text-gray-400">
             IMO {imo} / MMSI {mmsi}
           </p>
-          <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
+          <p className="mb-1 text-gray-700 dark:text-gray-400">
             <span className="font-bold">Vessel type</span> Fishing Vessel
           </p>
-          <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
+          <p className="mb-1 text-gray-700 dark:text-gray-400">
             <span className="font-bold">Vessel size:</span> {size} meters
           </p>
-          <p className="font-normal text-gray-700 dark:text-gray-400">
-            <span className="font-bold">Last position timestamp:</span>
+          <p className="text-gray-700 dark:text-gray-400">
+            <span className="font-bold">Last position:</span>
           </p>
-          <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
+          <p className="mb-1 text-gray-700 dark:text-gray-400">
             {position_timestamp}
           </p>
         </section>
@@ -88,8 +80,17 @@ const PreviewCard: React.FC<PreviewCardTypes> = ({ vesselInfo }) => {
           <Button onClick={() => handleDisplayTrail(mmsi)}>
             {isVesselTracked(mmsi) ? "Hide" : "Display"} trail
           </Button>
-          {isVesselTracked(mmsi) && <Link href="#">Show trail details</Link>}
+          {isVesselTracked(mmsi) && <Link href="#" className="ml-2">Show trail details</Link>}
         </section>
+
+        <div className="absolute right-0 top-0 pt-4 pr-3">
+        <IconButton
+            description="Close preview"
+            onClick={() => setActivePosition(null)}
+          >
+            <XIcon className="size-5 text-black dark:text-white" />
+          </IconButton>
+        </div> 
       </div>
     </div>
   )

--- a/components/dashboard/dashboard-overview.tsx
+++ b/components/dashboard/dashboard-overview.tsx
@@ -37,8 +37,8 @@ export default function DashboardOverview() {
             />
             <KPICard
               title="Total AMPs visited"
-              kpiValue={totalAmps}
-              totalValue={totalAmpsVisited}
+              kpiValue={totalAmpsVisited}
+              totalValue={totalAmps}
             />
             <KPICard
               title="Fishing effort"


### PR DESCRIPTION
minor fix: la popup de détails d'un bateau est sur la droite de l'écran (cache moins la carte)
minor fix: les bateaux selectionnées apparaissent d'une couleur différente sur la carte
major fix: seulement les trajectoires des bateaux selectionnés apparaissent sur la carte